### PR TITLE
Added a step to import the HAML templates on build, then delete.

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -24,6 +24,17 @@ if [ ! -d "PantheonCMD/pantheon-cmd-$1" ]; then
 
 fi
 
+# Get HAML templates
+mkdir PantheonCMD/haml
+
+echo 'Getting remote resources...'
+
+for FILE in block_admonition.html.haml block_image.html.haml block_page_break.html.haml block_stem.html.haml block_video.html.haml inline_button.html.haml inline_menu.html.haml block_audio.html.haml block_listing.html.haml block_paragraph.html.haml block_table.html.haml document.html.haml inline_callout.html.haml inline_quoted.html.haml block_colist.html.haml block_literal.html.haml block_pass.html.haml block_thematic_break.html.haml embedded.html.haml inline_footnote.html.haml section.html.haml block_dlist.html.haml block_olist.html.haml block_preamble.html.haml block_toc.html.haml helpers.rb inline_image.html.haml block_example.haml.haml block_open.html.haml block_quote.html.haml block_ulist.html.haml inline_anchor.html.haml inline_indexterm.html.haml block_floating_title.html.haml block_outline.html.haml block_sidebar.html.haml block_verse.html.haml inline_break.html.haml inline_kbd.html.haml
+do
+  echo Getting $FILE...
+  curl https://raw.githubusercontent.com/redhataccess/pantheon/master/pantheon-bundle/src/main/resources/apps/pantheon/templates/haml/html5/$FILE -o PantheonCMD/haml/$FILE -s > /dev/null
+done
+
 cp PantheonCMD/* PantheonCMD/pantheon-cmd-$1
 cp -r PantheonCMD/haml PantheonCMD/pantheon-cmd-$1
 cp -r PantheonCMD/resources PantheonCMD/pantheon-cmd-$1
@@ -57,4 +68,5 @@ rm PantheonCMD/pantheon-cmd-$1.tar.gz
 # Retrieve package
 cp ~/rpmbuild/RPMS/noarch/pantheon-cmd* build
 
-
+# Remove temporary HAML files
+rm -rf PantheonCMD/haml


### PR DESCRIPTION
Added support for importing the HAML templates into the repo during the RPM building process, then deleting them again on completion. 

Not a complete solution, but it does get around the need to store a copy in the repo itself, or set up git subtrees or submodules to import the resources for a relatively infrequent action.