### PR TITLE
Updated make.sh to replace remote CSS resources with local ones.

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -58,7 +58,7 @@ cp -r PantheonCMD/{haml,resources,utils,locales} PantheonCMD/pantheon-cmd-$1
 tar cvfz PantheonCMD/pantheon-cmd-$1.tar.gz -C PantheonCMD/ pantheon-cmd-$1
 
 # Create rpmbuild dir and structure if it doesn't already exist
-if [ ! -d "~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS,tmp}" ]; then
+if [ ! -d "~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS}" ]; then
     mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS}
 fi
 


### PR DESCRIPTION
Adds two sed commands to the make.sh script to replace references to remote resources with local ones.

Unless we update these values, styling only appears when the content is hosted on a web server.