### PR TITLE
Add RPM packaging prerequisites to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,20 @@ All additions and updates to the script are welcome.
 ## Packaging the Script
 After you update the manifest updater and test the changes, you can build an RPM-based package for the script so that it can be installed on systems that use *yum* or *dnf*.
 
-1. Open *./build/pantheon-cmd.spec*.
-2. Increment the value of the *Release* number.
-3. Run the build script:
-   ```
+1. Install the `svn` and `rpmbuild` packages installed on your system:
+   ```shell
+   # on RHEL
+   $ sudo yum install subversion
+   $ sudo yum install rpm-build
+
+   # on Fedora
+   $ sudo dnf install subversion
+   $ sudo dnf install rpm-build
+   ```  
+2. Open *./build/pantheon-cmd.spec*.
+3. Increment the value of the *Release* number.
+4. Run the build script:
+   ```shell
    $ sh make.sh 1.0
    ```
 
@@ -32,12 +42,20 @@ After you update the manifest updater and test the changes, you can build an RPM
 Install the RPM and all Ruby gem dependencies.
 
 1. Install the RPM:
-   ```
+   ```shell
    $ sudo dnf localinstall build/pantheon-cmd-1.0-X.el8.noarch.rpm
    ```
 2. Install Ruby gem dependencies:
-   ```
+   ```shell
    $ sudo gem install asciidoctor concurrent-ruby haml tilt
    ```
 
-Pantheon CMD is installed on your local machine.
+The script is installed on your local machine.
+The script provides the `pcmd` command.
+Enter `pcmd -h` in your terminal to view the basic usage instructions.
+
+## Licenscing
+
+This script uses locale attributes files from the AsciiDoctor repository.
+
+For more information, see https://github.com/asciidoctor/asciidoctor/tree/master/data/locale


### PR DESCRIPTION
@Levi-Leah @adahms I've updated `README.md` by adding some information about packages that are required to build the RPM.
I've learned about these while following the README and packaging the script locally on Fedora.

Please review the changes and let me know if  I should make any additions or adjustments. Thank you!     