### PR TITLE
Addresses the bug in additional recources checks

### DIFF
--- a/PantheonCMD/pcchecks.py
+++ b/PantheonCMD/pcchecks.py
@@ -48,7 +48,6 @@ class Regex:
     EMPTY_LINE_AFTER_ADD_RES_TAG = re.compile(r'\[role="_additional-resources"]\n(?=\n)')
     COMMENT_AFTER_ADD_RES_TAG = re.compile(r'\[role="_additional-resources"]\n(?=\//|(/{4,})(.*\n)*?(/{4,}))')
     EMPTY_LINE_AFTER_ADD_RES_HEADER = re.compile(r'== Additional resources\s\n|\.Additional resources\n\n', re.IGNORECASE)
-    COMMENT_AFTER_ADD_RES_HEADER = re.compile(r'\.Additional resources\s(?=\/\/|(\/{4,})(.*\n)*?(\/{4,}))|== Additional resources\s(?=\/\/|(\/{4,})(.*\n)*?(\/{4,}))', re.IGNORECASE)
 
 
 def icons_check(report, stripped_file, file_path):
@@ -196,13 +195,6 @@ def empty_line_after_add_res_header(stripped_file, original_file):
             return True
 
 
-# gives false positives if there's a normal and a commented out add res section
-def comment_after_add_res_header(stripped_file, original_file):
-    if stripped_file.count(Tags.ADD_RES) == 1:
-        if re.findall(Regex.COMMENT_AFTER_ADD_RES_HEADER, original_file):
-            return True
-
-
 def checks(report, stripped_file, original_file, file_path):
     """Run the checks."""
     if related_info_check(stripped_file):
@@ -225,9 +217,6 @@ def checks(report, stripped_file, original_file, file_path):
 
     if comment_after_add_res_tag(stripped_file, original_file):
         report.create_report('a comment after the additional resources tag was', file_path)
-
-    if comment_after_add_res_header(stripped_file, original_file):
-        report.create_report('a comment after the additional resources header was', file_path)
 
     if vanilla_xref_check(stripped_file):
         report.create_report('vanilla xrefs', file_path)

--- a/PantheonCMD/pcchecks.py
+++ b/PantheonCMD/pcchecks.py
@@ -48,7 +48,7 @@ class Regex:
     EMPTY_LINE_AFTER_ADD_RES_TAG = re.compile(r'\[role="_additional-resources"]\n(?=\n)')
     COMMENT_AFTER_ADD_RES_TAG = re.compile(r'\[role="_additional-resources"]\n(?=\//|(/{4,})(.*\n)*?(/{4,}))')
     EMPTY_LINE_AFTER_ADD_RES_HEADER = re.compile(r'== Additional resources\s\n|\.Additional resources\n\n', re.IGNORECASE)
-    COMMENT_AFTER_ADD_RES_HEADER = re.compile(r'\.Additional resources\s(?=\//|(/{4,})(.*\n)*?(/{4,}))|== Additional resources\s(?=\//|(/{4,})(.*\n)*?(/{4,}))', re.IGNORECASE)
+    COMMENT_AFTER_ADD_RES_HEADER = re.compile(r'\.Additional resources\s(?=\/\/|(\/{4,})(.*\n)*?(\/{4,}))|== Additional resources\s(?=\/\/|(\/{4,})(.*\n)*?(\/{4,}))', re.IGNORECASE)
 
 
 def icons_check(report, stripped_file, file_path):

--- a/PantheonCMD/pcchecks.py
+++ b/PantheonCMD/pcchecks.py
@@ -239,7 +239,7 @@ def checks(report, stripped_file, original_file, file_path):
         report.create_report('variable in the level 1 heading', file_path)
 
     if experimental_tag_check(stripped_file):
-        report.create_report('experimental tag not', file_path)
+        report.create_report('files contain UI macros but the :experimental: tag not', file_path)
 
     if html_markup_check(stripped_file):
         report.create_report('HTML markup', file_path)

--- a/PantheonCMD/pcchecks.py
+++ b/PantheonCMD/pcchecks.py
@@ -47,7 +47,7 @@ class Regex:
     ADD_RES_MODULE = re.compile(r'\.Additional resources', re.IGNORECASE)
     EMPTY_LINE_AFTER_ADD_RES_TAG = re.compile(r'\[role="_additional-resources"]\n(?=\n)')
     COMMENT_AFTER_ADD_RES_TAG = re.compile(r'\[role="_additional-resources"]\n(?=\//|(/{4,})(.*\n)*?(/{4,}))')
-    EMPTY_LINE_AFTER_ADD_RES_HEADER = re.compile(r'== Additional resources\s\n|\.Additional resources\s\n', re.IGNORECASE)
+    EMPTY_LINE_AFTER_ADD_RES_HEADER = re.compile(r'== Additional resources\s\n|\.Additional resources\n\n', re.IGNORECASE)
     COMMENT_AFTER_ADD_RES_HEADER = re.compile(r'\.Additional resources\s(?=\//|(/{4,})(.*\n)*?(/{4,}))|== Additional resources\s(?=\//|(/{4,})(.*\n)*?(/{4,}))', re.IGNORECASE)
 
 

--- a/PantheonCMD/pcvalidator.py
+++ b/PantheonCMD/pcvalidator.py
@@ -25,7 +25,7 @@ class Report():
         separator = "\n\t"
 
         for category, files in self.report.items():
-            print("\nFAIL: {} found in the following files:".format(category))
+            print("\nERROR: {} found in the following files:".format(category))
             print('\t' + separator.join(files))
 
 

--- a/PantheonCMD/pcyamlcheck.py
+++ b/PantheonCMD/pcyamlcheck.py
@@ -27,7 +27,7 @@ class Printing():
         separator = "\n\t"
 
         for message, items in self.report.items():
-            print("\nFAIL: the following {}:".format(message))
+            print("\nERROR: the following {}:".format(message))
             for item in items:
                 print('\t' + separator.join(item))
 


### PR DESCRIPTION
Addresses the following issues:
https://github.com/redhataccess/pantheon-cmd/issues/51 - change fail message to error
https://github.com/redhataccess/pantheon-cmd/issues/50 - improve the error message
https://github.com/redhataccess/pantheon-cmd/issues/49 - fix bug for comments after additional resources check (won't fix?)
https://github.com/redhataccess/pantheon-cmd/issues/48 - fix bug for empty line after additional resources check